### PR TITLE
2.5-pre4

### DIFF
--- a/target/.gitignore
+++ b/target/.gitignore
@@ -1,5 +1,0 @@
-/classes/
-/MANIFEST.MF
-/local-artifacts.properties
-/p2artifacts.xml
-/p2content.xml


### PR DESCRIPTION
Initial checkin after deriving from TelekomTV binding with the following changes:

Changes:
- change: periodically re-subsribe to the event channel, but do not re-pair
- change: the new key PAIR forces a re-pairing
- fix: "device already registered" on initialization
- fix: reset pairing on every connect
- refactored: network initialization is delayed to fix timing issue on startup

Refactoring as requested by PR / distro merge request
- Replaced usage of javax json to gson
- Exception handling revised, don't throw raw Exception
- log stack trace of exception in TRACE mode
- don't use logger.error(), instead use logger.warn with the prefix "FATAL:"

Signed-off-by: Markus Michels <markus7017@gmail.com> (github: markus7017) 